### PR TITLE
Autowire exception fix

### DIFF
--- a/src/main/java/org/mskcc/smile/service/util/RequestStatusLogger.java
+++ b/src/main/java/org/mskcc/smile/service/util/RequestStatusLogger.java
@@ -25,7 +25,6 @@ public class RequestStatusLogger {
 
     private File requestStatusLoggerFile;
 
-    @Autowired
     private static final String[] REQUEST_LOGGER_FILE_HEADER = new String[]{"DATE", "STATUS", "MESSAGE"};
 
     /**


### PR DESCRIPTION
Fix for the following error message:
```
2022-08-01 15:41:23.619  INFO 1 --- [           main] f.a.AutowiredAnnotationBeanPostProcessor : 
Autowired annotation is not supported on static fields: private static final java.lang.String[] 
org.mskcc.smile.service.util.RequestStatusLogger.REQUEST_LOGGER_FILE_HEADER
```

Signed-off-by: Divya Madala <71040191+divyamadala30@users.noreply.github.com>