### PR TITLE
Example code showing how to manual instrument using OpenTelemetry for Java (NOT TO BE MERGED)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,18 @@
     <smile_commons.version>1.3.6.RELEASE</smile_commons.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.17.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
       <!-- smile messaging library -->
     <dependency>
@@ -98,6 +110,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.11</version>
+    </dependency>
+    <!-- otel -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/mskcc/smile/service/ValidRequestChecker.java
+++ b/src/main/java/org/mskcc/smile/service/ValidRequestChecker.java
@@ -2,11 +2,12 @@ package org.mskcc.smile.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import io.opentelemetry.api.trace.Span;
 import java.io.IOException;
 import java.util.Map;
 
 public interface ValidRequestChecker {
-    String getFilteredValidRequestJson(String requestJson)
+    String getFilteredValidRequestJson(Span parentSpan, String requestJson)
             throws JsonMappingException, JsonProcessingException, IOException;
     Boolean hasValidRequestLevelMetadata(String requestJson)
             throws JsonMappingException, JsonProcessingException, IOException;


### PR DESCRIPTION
First foray into manual instrumentation using OpenTelemetry for Java.  Code should not be merged as it may not be best practice.  For example [code passes a parent span](https://github.com/mskcc/smile-request-filter/blob/92f00881f335b288eccbe5ba9555d2b36d7ddbf5/src/main/java/org/mskcc/smile/service/impl/RequestFilterMsgHandlingServiceIml.java#L90) from the RequestFilterHandler to validRequestChecker.getFilteredValidRequestJson through a method call.  This may not be the best way to do this - further investigation is required. 

Also missing is use of  tracer.setSpanKind([Span.Kind](https://javadoc.io/static/io.opentelemetry/opentelemetry-api/0.9.0/io/opentelemetry/trace/Span.Kind.html)) which may be helpful in Jaeger (or Datadog UI) as well as setting the [span status](https://opentelemetry.io/docs/instrumentation/java/manual/#set-span-status)

Question - how are OpenTelemetry Tags used?  Can we set a RequestID tag?  Would that be useful?

See OpenTelemetry [Manual Instrumentation in Java](https://opentelemetry.io/docs/instrumentation/java/manual/) for more information. 