### PR TITLE
Add validationStatus to request and sample level data

### DIFF
--- a/src/main/java/org/mskcc/smile/service/ValidRequestChecker.java
+++ b/src/main/java/org/mskcc/smile/service/ValidRequestChecker.java
@@ -8,15 +8,17 @@ import java.util.Map;
 public interface ValidRequestChecker {
     String getFilteredValidRequestJson(String requestJson)
             throws JsonMappingException, JsonProcessingException, IOException;
-    Boolean hasValidRequestLevelMetadata(String requestJson)
+    Map<String, Object> generateRequestStatusValidationMap(String requestJson)
             throws JsonMappingException, JsonProcessingException, IOException;
-    Boolean isValidCmoSample(Map<String, String> sampleMap)
+    Map<String, Object> generateCmoSampleValidationMap(Map<String, Object> sampleMap)
             throws JsonMappingException, JsonProcessingException;
-    Boolean isValidNonCmoSample(Map<String, String> sampleMap)
+    Map<String, Object> generateNonCmoSampleValidationMap(Map<String, Object> sampleMap)
             throws JsonMappingException, JsonProcessingException;
     Boolean isCmo(String json) throws JsonProcessingException;
     String getRequestId(String json) throws JsonProcessingException;
     Boolean hasRequestId(String json) throws JsonProcessingException;
-    Boolean isValidPromotedRequest(String requestJson) throws JsonMappingException,
+    Map<String, Object> generatePromotedRequestValidationMap(String requestJson) throws JsonMappingException,
             JsonProcessingException, IOException;
+    Map<String, Object> generatePromotedSampleValidationMap(Map<String, Object> sampleMap)
+            throws JsonMappingException, JsonProcessingException;
 }

--- a/src/main/java/org/mskcc/smile/service/impl/PromotedRequestMsgHandlingServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/PromotedRequestMsgHandlingServiceImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.nats.client.Message;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -74,7 +75,11 @@ public class PromotedRequestMsgHandlingServiceImpl implements PromotedRequestMsg
                 try {
                     String requestJson = promotedRequestQueue.poll(100, TimeUnit.MILLISECONDS);
                     if (requestJson != null) {
-                        if (validRequestChecker.isValidPromotedRequest(requestJson)) {
+                        Map<String, Object> promotedRequestJsonMap =
+                                validRequestChecker.generatePromotedRequestValidationMap(requestJson);
+                        Map<String, Object> requestStatus =
+                                mapper.convertValue(promotedRequestJsonMap.get("status"), Map.class);
+                        if ((Boolean) requestStatus.get("validationStatus")) {
                             // if request is cmo then publish to CMO_PROMOTED_LABEL_TOPIC
                             // otherwise publish to IGO_PROMOTED_REQUEST_TOPIC
                             String topic = validRequestChecker.isCmo(requestJson)

--- a/src/main/java/org/mskcc/smile/service/util/RequestStatusLogger.java
+++ b/src/main/java/org/mskcc/smile/service/util/RequestStatusLogger.java
@@ -30,6 +30,7 @@ public class RequestStatusLogger {
     /**
      * Request StatusType descriptions:
      * - REQUEST_WITH_MISSING_SAMPLES: a request that came in with no sample metadata
+     * - REQUEST_MISSING_REQUEST_ID: a request missing a request id
      * - CMO_REQUEST_WITH_SAMPLES_MISSING_CMO_LABEL_FIELDS: a CMO request with sample metadata
      *        that is missing required fields (cmoPatientId, baitSet)
      * - REQUEST_PARSING_ERROR: json parsing exception thrown
@@ -49,6 +50,7 @@ public class RequestStatusLogger {
      */
     public enum StatusType {
         REQUEST_WITH_MISSING_SAMPLES,
+        REQUEST_MISSING_REQUEST_ID,
         CMO_REQUEST_WITH_SAMPLES_MISSING_CMO_LABEL_FIELDS,
         REQUEST_PARSING_ERROR,
         CMO_REQUEST_FILTER_SKIPPED_REQUEST,


### PR DESCRIPTION
Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

# Support validation status information for requests and request samples

Briefly describe changes proposed in this pull request:
- adds "status" to request metadata and sample metadata 
- status contains validation information, including what field(s) failed validation
- if a request has at least one sample that passes validation then it is considered valid still

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Data checklist
Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:**
Updates were made to the mocked incoming request data and/or mocked published request data:

- [ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)
- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)
- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)
- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)


### II. Message handlers checklist:
- [ ] Changes introduced affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added or updated to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### III. Configuration and/or permissions checklist:
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.

---
### Screenshots

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
