### PR TITLE
Bug fix for checking fastqs

### DIFF
--- a/src/main/java/org/mskcc/smile/service/impl/ValidRequestCheckerImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/ValidRequestCheckerImpl.java
@@ -438,11 +438,11 @@ public class ValidRequestCheckerImpl implements ValidRequestChecker {
         for (Object lib : libraries) {
             Map<String, Object> libMap = mapper.convertValue(lib, Map.class);
             if (!libMap.containsKey("runs")) {
-                return Boolean.FALSE;
+                continue;
             }
             List<Object> runs = mapper.convertValue(libMap.get("runs"), List.class);
             if (runs.isEmpty()) {
-                return Boolean.FALSE;
+                continue;
             }
             for (Object run : runs) {
                 Map<String, Object> runMap = mapper.convertValue(run, Map.class);

--- a/src/test/resources/data/incoming_requests/mocked_request1_complete_tumor_normal.json
+++ b/src/test/resources/data/incoming_requests/mocked_request1_complete_tumor_normal.json
@@ -208,6 +208,17 @@
               "flowCellLanes": [
                 5
               ],
+              "fastqs": []
+            },
+            {
+              "runMode": "HiSeq High Output",
+              "runId": "RUNID_0123",
+              "flowCellId": "X5KL2KKAY",
+              "readLength": "",
+              "runDate": "2018-06-05",
+              "flowCellLanes": [
+                5
+              ],
               "fastqs": [
                 "/FASTQ/Project_MOCKREQUEST1_B/Sample_01-XXXXXXXa_IGO_MOCKREQUEST1_B_4/01-XXXXXXXa_IGO_MOCKREQUEST1_B_4_S85_R1_001.fastq.gz",
                 "/FASTQ/Project_MOCKREQUEST1_B/Sample_01-XXXXXXXa_IGO_MOCKREQUEST1_B_4/01-XXXXXXXa_IGO_MOCKREQUEST1_B_4_S85_R2_001.fastq.gz"


### PR DESCRIPTION
Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

# Bug fix for checking fastqs

Briefly describe changes proposed in this pull request:
- validation will pass if a sample has at least one set of fastqs
- updated the mocked sample metadata to have multiple runs with the first run in the list having no fastqs defined. 
  - validation succeeds with the change in the validator behavior and fails without the code change as expected