### PR TITLE
Bug fix: always publish requests or samples even when validation fails

### DIFF
--- a/src/main/java/org/mskcc/smile/service/impl/PromotedRequestMsgHandlingServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/PromotedRequestMsgHandlingServiceImpl.java
@@ -74,6 +74,9 @@ public class PromotedRequestMsgHandlingServiceImpl implements PromotedRequestMsg
                                 validRequestChecker.generatePromotedRequestValidationMap(requestJson);
                         Map<String, Object> requestStatus =
                                 mapper.convertValue(promotedRequestJsonMap.get("status"), Map.class);
+                        // TODO: Promoted requests are still not supported. If in the future this changes,
+                        // and it is desired, then the promoted request json should be updated with the
+                        // request status map
                         if ((Boolean) requestStatus.get("validationStatus")) {
                             // if request is cmo then publish to CMO_PROMOTED_LABEL_TOPIC
                             // otherwise publish to IGO_PROMOTED_REQUEST_TOPIC

--- a/src/main/java/org/mskcc/smile/service/impl/RequestFilterMsgHandlingServiceIml.java
+++ b/src/main/java/org/mskcc/smile/service/impl/RequestFilterMsgHandlingServiceIml.java
@@ -78,25 +78,27 @@ public class RequestFilterMsgHandlingServiceIml implements RequestFilterMessageH
                             if (passCheck) {
                                 LOG.info("Request'" + requestId + "' passed sanity check, publishing to: "
                                         + CMO_LABEL_GENERATOR_TOPIC);
-                                // even if sanity check passed there might still be information worth
-                                // reporting from the sample-level validation reports
-                                messagingGateway.publish(requestId,
+                            } else {
+                                LOG.error("Sanity check failed on request: " + filteredRequestJson);
+                            }
+                            // even if sanity check failed there might still be information worth
+                            // reporting from the sample-level validation reports
+                            messagingGateway.publish(requestId,
                                     CMO_LABEL_GENERATOR_TOPIC,
                                     filteredRequestJson);
-                            } else {
-                                LOG.error("Sanity check failed on request: " + requestId);
-                            }
                         } else {
                             LOG.info("Handling non-CMO request...");
                             if (passCheck) {
                                 LOG.info("Request '" + requestId + "' passed sanity check, publishing to: "
                                         + IGO_NEW_REQUEST_TOPIC);
-                                messagingGateway.publish(requestId,
-                                        IGO_NEW_REQUEST_TOPIC,
-                                        filteredRequestJson);
                             } else {
-                                LOG.error("Sanity check failed on request: " + requestId);
+                                LOG.error("Sanity check failed on request: " + filteredRequestJson);
                             }
+                            // even if sanity check failed there might still be information worth
+                            // reporting from the sample-level validation reports
+                            messagingGateway.publish(requestId,
+                                    IGO_NEW_REQUEST_TOPIC,
+                                    filteredRequestJson);
                         }
                         // data dog log message
                         String ddogLogMessage = validRequestChecker.generateValidationReport(


### PR DESCRIPTION
# Bug fix: always publish requests or samples even when validation fails

**Briefly describe changes proposed in this pull request:**

The update message handlers were updated to always attach and logging the request/sample statuses even when they fail validation.

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Message handlers checklist:
- [x] Changes introduced affect the workflow of incoming messages.
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added or updated to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, **dev server**, production]
- Neo4j [local, local docker, **dev server**, production]
- SMILE Server [local, local docker, **dev server**, production]
- Message publishing simulation [nats cli, docker nats cli, **smile publisher tool**, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### II. Configuration and/or permissions checklist: n/a
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
