### PR TITLE
Update checkstyle and smile dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,10 @@
     <jackson.version>2.17.2</jackson.version>
     <!-- smile messaging -->
     <smile_messaging_java.group>com.github.mskcc</smile_messaging_java.group>
-    <smile_messaging_java.version>2.0.8.RELEASE</smile_messaging_java.version>
+    <smile_messaging_java.version>2.1.0.RELEASE</smile_messaging_java.version>
     <!-- smile commons centralized config properties -->
     <smile_commons.group>com.github.mskcc</smile_commons.group>
-    <smile_commons.version>2.0.7.RELEASE</smile_commons.version>
+    <smile_commons.version>2.1.0.RELEASE</smile_commons.version>
   </properties>
 
   <dependencies>
@@ -135,7 +135,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.0</version>
         <dependencies>
           <dependency>
             <groupId>${smile_commons.group}</groupId>


### PR DESCRIPTION
Briefly describe changes proposed in this pull request:
- updates smile-commons to 2.1.0.RELEASE
- updates smile-messaging-java to 2.1.0.RELEASE
- updates maven-checkstyle to 3.6.0
